### PR TITLE
Don't read local bitcoin.conf if :config is passed in

### DIFF
--- a/src/clj_btc/core.clj
+++ b/src/clj_btc/core.clj
@@ -41,14 +41,12 @@
 
 (defn- do-rpc
   [name doc args premap]
-  (let [args-form ['& {:keys (vec (cons 'config args))
-                       :or '{config (read-local-config)}}]
-        premap (merge-with (comp vec concat)
-                           {:pre `[(map? ~'config)]}
-                           premap)]
+  (let [args-form ['& {:keys (vec (cons 'config args))}]]
     `(defn ~name ~doc ~args-form
        ~premap
-       (let [params# (vec (take-while not-nil? ~args))]
+       (let [~'config (or ~'config (read-local-config))
+             params# (vec (take-while not-nil? ~args))]
+         (assert (map? ~'config))
          (rpc-call ~'config ~(str name) params#)))))
 
 (defmacro ^:private defrpc


### PR DESCRIPTION
Change `clj-btc.core/do-rpc` to only read from the local config file if :config is not provided. Previously it was reading from the file regardless before defaulting to the user-supplied config-map.

Shouldn't cause any client API breakage.
